### PR TITLE
Add mocha to eslint environment for simulator

### DIFF
--- a/simulator/.eslintrc.json
+++ b/simulator/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "commonjs": true,
     "es6": true,
-    "node": true
+    "node": true,
+		"mocha": true
   },
   "extends": ["airbnb-base", "plugin:prettier/recommended"],
   "globals": {


### PR DESCRIPTION
This solves the issue with eslint reporting that "describe" and "it" in the test suites are undefined.