### PR TITLE
Dashboard blocked display

### DIFF
--- a/app/client/js/dashboard/manager/prosumerOverview/prosumerOverview.js
+++ b/app/client/js/dashboard/manager/prosumerOverview/prosumerOverview.js
@@ -1,4 +1,3 @@
-// const POLL_INTERVAL = 3000;
 document.addEventListener("DOMContentLoaded", () => {
   pollFunc(updateData, POLL_INTERVAL);
 });

--- a/app/client/js/dashboard/prosumer/dashboard.js
+++ b/app/client/js/dashboard/prosumer/dashboard.js
@@ -18,9 +18,10 @@ async function updateData() {
     "consumption"
   ).innerHTML = prosumer.currentConsumption.toFixed(2);
 
-  document.getElementById("block-status").innerText = prosumer.blocked
-    ? "You are blocked from selling"
+  document.getElementById("block-status").innerHTML = prosumer.blocked
+    ? "<i data-feather='x-octagon' style=color:red></i> You are blocked from selling"
     : "";
+  feather.replace();
 
   const netProd = prosumer.currentProduction - prosumer.currentConsumption;
   document.getElementById("netProduction").innerHTML = netProd.toFixed(2);

--- a/app/client/js/prosumerSummary/prosumerStatsTable.js
+++ b/app/client/js/prosumerSummary/prosumerStatsTable.js
@@ -20,9 +20,10 @@ async function updateData() {
     "consumption"
   ).innerHTML = prosumer.currentConsumption.toFixed(2);
 
-  document.getElementById("block-status").innerText = prosumer.blocked
-    ? "Blocked from selling"
+  document.getElementById("block-status").innerHTML = prosumer.blocked
+    ? "<i data-feather='x-octagon' style=color:red></i> Blocked from selling"
     : "";
+  feather.replace();
 
   const netProd = prosumer.currentProduction - prosumer.currentConsumption;
   document.getElementById("netProduction").innerHTML = netProd.toFixed(2);

--- a/app/client/views/pages/prosumerDashboard.ejs
+++ b/app/client/views/pages/prosumerDashboard.ejs
@@ -9,6 +9,7 @@
       type="text/javascript"
       src="/js/dashboard/prosumer/displayRatios.js"
     ></script>
+    <script src="https://unpkg.com/feather-icons"></script>
     <script type="text/javascript" src="/js/dashboard/data.js"></script>
     <script
       type="text/javascript"
@@ -44,7 +45,7 @@
               The ratio of electricity sold to the market and stored in the
               battery during excessive production
             </p>
-            <span id="block-status"></span>
+            <p class="card-text" id="block-status"></p>
             <label id="displayExcessBatteryRatio" for="ratioExcess"></label>
             <%- include("../partials/slider", {id:"ratioExcess"}) %>
             <label id="displayExcessMarketRatio" for="ratioExcess"></label>

--- a/app/client/views/pages/prosumerSummary.ejs
+++ b/app/client/views/pages/prosumerSummary.ejs
@@ -6,6 +6,7 @@
 	<%- include("../partials/bootstrap") %>
 	<script type="text/javascript" src="/js/util.js"></script>
 	<script type="text/javascript" src="/js/fragments/fragments.js"></script>
+	<script src="https://unpkg.com/feather-icons"></script>
 	<script 
 		type="text/javascript" 
 		src="/js/prosumerSummary/prosumerStatsTable.js"
@@ -45,7 +46,7 @@
 						The ratio of electricity sold to the market and stored in the
 						battery during excessive production
 					</p>
-					<p id="block-status"></p>
+					<p class="card-text" id="block-status"></p>
 					<label id="displayExcessBatteryRatio" for="ratioExcess">0</label>
 					<%- include("../partials/slider", {id:"ratioExcess"}) %>
 					<label id="displayExcessMarketRatio" for="ratioExcess">100</label>


### PR DESCRIPTION
Added a red blocked icon with the blocked text on prosumer dashboard and summary. Also fixed issue with prosumer overview not updating since poll interval was redeclared.
Closes #179 