### PR TITLE
Prosumer dashboard blackout

### DIFF
--- a/app/client/js/dashboard/prosumer/dashboard.js
+++ b/app/client/js/dashboard/prosumer/dashboard.js
@@ -19,6 +19,7 @@ async function updateData() {
 							currentWindSpeed
 							currentProduction
 							currentConsumption
+							blackout
 							blocked
 							battery{
 								power
@@ -46,10 +47,13 @@ async function updateData() {
       "consumption"
     ).innerHTML = prosumer.currentConsumption.toFixed(2);
 
-  document.getElementById("block-status").innerHTML = prosumer.blocked
-    ? "<i data-feather='x-octagon' style=color:red></i> You are blocked from selling"
-    : "";
-  feather.replace();
+    document.getElementById("block-status").innerHTML = prosumer.blocked
+      ? "<i data-feather='x-octagon' style=color:red></i> You are blocked from selling"
+      : "";
+    document.getElementById("blackout-status").innerHTML = prosumer.blackout
+      ? "<i data-feather='alert-triangle' style=color:red></i> You are currently experiencing a blackout"
+      : "";
+    feather.replace();
 
     const netProd = prosumer.currentProduction - prosumer.currentConsumption;
     document.getElementById("netProduction").innerHTML = netProd.toFixed(2);

--- a/app/client/js/fragments/fragments.js
+++ b/app/client/js/fragments/fragments.js
@@ -20,6 +20,7 @@ fragment prosumerFields on prosumer {
 	ratioExcessMarket,
 	ratioDeficitMarket,
 	blocked,
+	blackout,
 	battery {
 		power,
 		maxCapacity

--- a/app/client/js/prosumerSummary/prosumerStatsTable.js
+++ b/app/client/js/prosumerSummary/prosumerStatsTable.js
@@ -23,6 +23,9 @@ async function updateData() {
   document.getElementById("block-status").innerHTML = prosumer.blocked
     ? "<i data-feather='x-octagon' style=color:red></i> Blocked from selling"
     : "";
+  document.getElementById("blackout-status").innerHTML = prosumer.blackout
+    ? "<i data-feather='alert-triangle' style=color:red></i> Prosumer is currently experiencing a blackout"
+    : "";
   feather.replace();
 
   const netProd = prosumer.currentProduction - prosumer.currentConsumption;

--- a/app/client/views/pages/prosumerDashboard.ejs
+++ b/app/client/views/pages/prosumerDashboard.ejs
@@ -33,6 +33,7 @@
         <div class="card">
           <h3 class="card-header">Overview</h3>
           <div class="card-body">
+            <p id="blackout-status" class="card-text"></p>
             <%- include("../partials/prosumerStatsTable") %>
           </div>
         </div>

--- a/app/client/views/pages/prosumerSummary.ejs
+++ b/app/client/views/pages/prosumerSummary.ejs
@@ -36,8 +36,10 @@
 			</div>
 			<div class="card">
 				<h3 class="card-header">Overview</h3>
-				<p id="blackout-status" class="card-text"></p>
-				<%- include("../partials/prosumerStatsTable") %>
+				<div class="card-body">
+					<p id="blackout-status" class="card-text"></p>
+					<%- include("../partials/prosumerStatsTable") %>
+				</div>
 			</div>
 			<div class="card">
 				<h3 class="card-header">Ratios</h3>

--- a/app/client/views/pages/prosumerSummary.ejs
+++ b/app/client/views/pages/prosumerSummary.ejs
@@ -36,6 +36,7 @@
 			</div>
 			<div class="card">
 				<h3 class="card-header">Overview</h3>
+				<p id="blackout-status" class="card-text"></p>
 				<%- include("../partials/prosumerStatsTable") %>
 			</div>
 			<div class="card">


### PR DESCRIPTION
Blackouts are now displayed and indicated on the prosumer dashboard as well as the prosumer summary. Also fixed and issue with the simulation logic which made the prosumers experience blackouts while they still had power stored in their battery due to always setting blackout if market supply couldn't cover the entire market amount.

Closes #186.